### PR TITLE
(INFC-18852) update solaris pkg name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,8 +125,8 @@ class ssh::params (
           $ssh_service    = 'svc:/network/cswopenssh:default'
         }
         '11': {
-          $client_package = 'service/network/ssh'
-          $server_package = 'service/network/ssh'
+          $client_package = 'network/ssh'
+          $server_package = 'network/ssh'
           $ssh_service    = 'network/ssh'
         }
         default: {


### PR DESCRIPTION
I don't think these package names are correct so this PR is to correct them.  Before:

```
Debug: Executing: '/usr/bin/pkg list -Hv service/network/ssh'
Debug: Executing: '/usr/bin/pkg unfreeze service/network/ssh'
Debug: Executing: '/usr/bin/pkg list -Hv service/network/ssh'
Debug: Executing: '/usr/bin/pkg install --accept --sync-actuators-timeout 900 service/network/ssh'
Error: Unable to update  Startup: Refreshing catalog 'solarisstudio' ... Done
 Startup: Refreshing catalog 'solaris' ... Done
 Startup: Refreshing catalog 'plops' ... Done
 Startup: Refreshing catalog 'puppetlabs.com' ... Done
Planning: Solver setup ... Done
Planning: Running solver ... Done
Planning: Consolidating action changes ... Done
Planning: Evaluating mediators ... Done
Planning: Planning completed in 3.22 seconds
No updates necessary for this image.
```
The result was a failure in the catalog and skipped resources.
After this change I do not see this error.  Additionally, on Solaris 11.3:
```
-bash-4.1# pkg list -af 'service/network/ssh'
NAME (PUBLISHER)                                  VERSION                    IFO
service/network/ssh (solaris)                     7.7.0.1-11.4.7.0.1.3.0     ---
service/network/ssh (solaris)                     7.7.0.1-11.4.6.0.1.2.0     ---
service/network/ssh (solaris)                     7.5.0.1-11.4.0.0.1.14.0    ---
service/network/ssh (solaris)                     0.5.11-0.175.3.1.0.2.0     --r
```
[According to the docs](https://docs.oracle.com/cd/E26502_01/html/E28984/gkoic.html), the `r` in the thrid column means that the package has been renamed.
