### PR TITLE
Completely subbed and stubbed windows acl provider

### DIFF
--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,25 +1,15 @@
 require 'spec_helper'
+require 'puppet/util/windows'
 
 describe 'ssh::server' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:puppet_util_windows_security) do
-        class_double('Puppet::Util::Windows::Security').as_stubbed_const(transfer_nested_constants: true)
-      end
-      let(:puppet_util_windows_file) do
-        class_double('Puppet::Util::Windows::File').as_stubbed_const(transfer_nested_constants: true)
-      end
-      let(:puppet_util_windows_sid) do
-        class_double('Puppet::Util::Windows::SID').as_stubbed_const(transfer_nested_constants: true)
+      let(:win_acl_provider) do
+        Puppet::Type.type(:acl).provide :windows
       end
       let(:pre_condition) do
-        allow(puppet_util_windows_security).to receive(:valid_sid?).and_return(true)
-        allow(puppet_util_windows_file).to receive(:symlink?).and_return(false)
-        allow(puppet_util_windows_sid).to receive(:respond_to?).with(:valid_sid?).and_return(true)
-        allow(puppet_util_windows_sid).to receive(:respond_to?).with(:sid_to_name).and_return(true)
-        allow(puppet_util_windows_sid).to receive(:sid_to_name)
-        allow(puppet_util_windows_sid).to receive(:valid_sid?).and_return(true)
+        allow(win_acl_provider).to receive(:validate).and_return(true)
       end
 
       it { is_expected.to compile }

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,7 +1,0 @@
-# This is needed to test puppetlabs/acl on OSs other than Windows. If it's not
-# present, then `pdk test unit` gives errors like:
-#
-# undefined method `symlink?' for Puppet::Util::Windows::File:Module
-RSpec.configure do |c|
-  c.mock_with :rspec
-end


### PR DESCRIPTION
This leaves a lot to be desired as far as testing functionality goes, because this completely short-circuits the call to `validate` and all subsequent method calls. However, since the test in question is only testing to see if everything compiles this allows that to happen.