### PR TITLE
Fix duplicate acl properties and file permissions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -279,6 +279,7 @@ The following parameters are available in the `ssh::authorized_key::file` define
 * [`ensure`](#ensure)
 * [`user`](#user)
 * [`group`](#group)
+* [`mode`](#mode)
 
 ##### <a name="ensure"></a>`ensure`
 
@@ -303,6 +304,14 @@ Data type: `String[1]`
 The group permissions of the authorized key file.
 
 Default value: `'NT AUTHORITY\SYSTEM'`
+
+##### <a name="mode"></a>`mode`
+
+Data type: `Optional[String[3]]`
+
+The file mode to set for the ssh authorized key file.
+
+Default value: `$ssh::params::config_mode`
 
 ### <a name="sshchrootgroup"></a>`ssh::chrootgroup`
 

--- a/manifests/authorized_key/file.pp
+++ b/manifests/authorized_key/file.pp
@@ -47,11 +47,12 @@ define ssh::authorized_key::file (
       acl { $path:
         purge                      => true,
         inherit_parent_permissions => false,
-        permissions                => [
-          { 'identity' => $group, 'rights' => ['full'] },
-          { 'identity' => $owner, 'rights' => ['full'] },
-          { 'identity' => $user,  'rights' => ['full'] },
-        ],
+        permissions                => unique([
+            { 'identity' => $group, 'rights' => ['full'] },
+            { 'identity' => $owner, 'rights' => ['full'] },
+            { 'identity' => $user, 'rights' => ['full'] },
+          ],
+        ),
       }
     }
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -191,8 +191,8 @@ class ssh::params (
       $has_restart       = false
       $config_owner      = 'Administrators'
       $config_group      = 'NT AUTHORITY\SYSTEM'
-      $config_mode       = undef # Use ACLs
-      $config_dir_mode   = undef
+      $config_mode       = '0774'
+      $config_dir_mode   = '0774'
       $root_access_group = 'Administrators'
       $syslog_facility   = 'AUTH'
       $print_motd        = true


### PR DESCRIPTION
This fixes 2 things:

1. Duplicate permissions attempting to be applied by an acl resource
2. File mode permissions on windows, because the concat and acl resource conflict with each other, resulting in a flipping permissions back and forth on every puppet run like:
```powershell
Warning: Setting control rights for C:/ProgramData/ssh/sshd_config group SYSTEM to less than Full Control rights. Setting SYSTEM rights to less than Full Control may have unintented consequences for operations on this file
Notice: /Stage[main]/Ssh::Server/Concat[ssh::params::sshd_config]/File[C:\ProgramData\ssh/sshd_config]/mode: mode changed '0774' to '0644' (corrective)
Info: Unknown failure using insync_values? on type: Acl[C:\ProgramData\ssh/sshd_config] / property: permissions to compare values [{"identity"=>"BUILTIN\\Administrators", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"Everyone", "rights"=>["read"], "affects"=>:self_only}] and [
 { identity => 'BUILTIN\Administrators', rights => ["mask_specific"], mask => '2032031', affects => 'self_only' },
 { identity => 'NT AUTHORITY\SYSTEM', rights => ["read"], affects => 'self_only' },
 { identity => 'Everyone', rights => ["read"], affects => 'self_only' }]
Notice: /Stage[main]/Ssh::Server::Chocolatey/Acl[C:\ProgramData\ssh/sshd_config]/permissions: permissions changed [{"identity"=>"BUILTIN\\Administrators", "rights"=>["mask_specific"], "mask"=>"2032031", "affects"=>:self_only}, {"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["read"], "affects"=>:self_only}, {"identity"=>"Everyone", "rights"=>["read"], "affects"=>:self_only}] to [{"identity"=>"BUILTIN\\Administrators", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"Everyone", "rights"=>["read"], "affects"=>:self_only}]
```

and:
```powershell
Notice: /Stage[main]/Main/Concat[ssh::authorized_key::file test.user]/File[C:\ProgramData\ssh\user_authorized_keys\test.user]/mode: mode changed '2000744' to '0644'
Notice: /Stage[main]/Main/Acl[C:\ProgramData\ssh\user_authorized_keys\test.user]/permissions: permissions changed [{"identity"=>"BUILTIN\\Administrators", "rights"=>["mask_specific"], "mask"=>"2032031", "affects"=>:self_only}, {"identity"=>"LOCALHOST\\None", "rights"=>["read"], "affects"=>:self_only}, {"identity"=>"Everyone", "rights"=>["read"], "affects"=>:self_only}, {"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}] to [{"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"Everyone", "rights"=>["read"], "affects"=>:self_only}, {"identity"=>"VEEAM-AP-PROD-1\\test.user", "rights"=>["full"], "affects"=>:self_only}]
```